### PR TITLE
Exception Handling in RxHttpClient

### DIFF
--- a/src/main/java/meez/rxvertx/java/http/RxHttpClient.java
+++ b/src/main/java/meez/rxvertx/java/http/RxHttpClient.java
@@ -199,8 +199,12 @@ public class RxHttpClient {
     
     // Use the builder to create the full request (or start upload)
     // We assume builder will call request.end()
-    builder.call(req);
-    
+    try {
+        builder.call(req);
+    } catch(Exception e) {
+        rh.fail(e);
+    }
+
     return Observable.create(rh.subscribe);
   }
 }

--- a/src/main/java/meez/rxvertx/java/http/RxHttpClient.java
+++ b/src/main/java/meez/rxvertx/java/http/RxHttpClient.java
@@ -2,6 +2,7 @@ package meez.rxvertx.java.http;
 
 import meez.rxvertx.java.impl.MemoizeHandler;
 import meez.rxvertx.java.impl.ResultMemoizeHandler;
+import org.vertx.java.core.Handler;
 import org.vertx.java.core.http.*;
 import rx.Observable;
 import rx.util.functions.Action1;
@@ -187,6 +188,14 @@ public class RxHttpClient {
     };
     
     HttpClientRequest req= core.request(method,uri,rh);
+
+    // if req fails, notify observers
+    req.exceptionHandler(new Handler<Exception>() {
+        @Override
+        public void handle(Exception event) {
+            rh.fail(event);
+        }
+    });
     
     // Use the builder to create the full request (or start upload)
     // We assume builder will call request.end()


### PR DESCRIPTION
Added exception handling in case HttpClientRequest fails in RxHttpClient.request() or if builder call-back throws an Exception.
